### PR TITLE
Metrics output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2948,6 +2948,7 @@ dependencies = [
  "lru 0.12.5",
  "parking_lot",
  "portpicker",
+ "prometheus",
  "rand 0.8.5",
  "reqwest",
  "serde",

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -39,6 +39,7 @@ simple_moving_average = "1"
 bytesize = "1"
 serde_derive = "1.0.217"
 hex = "0.4.3"
+prometheus = "0.13"
 
 [[example]]
 name = "all"

--- a/crates/examples/all.rs
+++ b/crates/examples/all.rs
@@ -312,6 +312,7 @@ async fn main() -> Result<()> {
                         args.num_transactions_per_view,
                         args.transaction_size,
                         args.num_views,
+                        None,
                     )
                     .await?,
                 );
@@ -344,6 +345,7 @@ async fn main() -> Result<()> {
                         args.num_transactions_per_view,
                         args.transaction_size,
                         args.num_views,
+                        None,
                     )
                     .await?,
                 );
@@ -358,6 +360,7 @@ async fn main() -> Result<()> {
                     &public_key,
                     &private_key,
                     &known_libp2p_nodes,
+                    None,
                 )
                 .await
                 .with_context(|| "Failed to create Libp2p network")?;
@@ -377,6 +380,7 @@ async fn main() -> Result<()> {
                         args.num_transactions_per_view,
                         args.transaction_size,
                         args.num_views,
+                        None,
                     )
                     .await?,
                 );

--- a/crates/examples/common.rs
+++ b/crates/examples/common.rs
@@ -12,6 +12,7 @@ include!("rpc.rs");
 include!("metrics.rs");
 
 /// initialize prom metrics
+#[must_use]
 pub fn init_metrics(port: Option<u16>, metrics_folder: Option<String>) -> Arc<PrometheusMetrics> {
     // Create a new metrics instance
     let registry = prometheus::Registry::new();

--- a/crates/examples/common.rs
+++ b/crates/examples/common.rs
@@ -286,7 +286,7 @@ async fn start_consensus<
         start_rpc(rpc_port, tx_send.clone()).await;
     });
 
-    match met {
+    match met.clone() {
         Some(m) => {
             let metrics_cloned = m.clone();
             tokio::spawn(async move {
@@ -304,6 +304,10 @@ async fn start_consensus<
         None => {}
     }
 
+    let metrics_cloned = match met {
+        Some(m) => m.clone(),
+        None => init_metrics(None),
+    };
     // Spawn the task to wait for events
     let join_handle = tokio::spawn(async move {
         // Get the event stream for this particular node
@@ -445,6 +449,20 @@ async fn start_consensus<
                                 // Break when we've decided on the view number we requested
                                 break;
                             }
+                        }
+
+                        if *qc.view_number % 100 == 0 {
+                            // print metrics every 100 views
+                            let collected_metrics = metrics_cloned.gather();
+                            match collected_metrics {
+                                Some(metrics) => {
+                                    println!("----\nMETRICS----\n{metrics}");
+                                }
+                                None => {
+                                    info!("No metrics collected");
+                                }
+                            }
+                            break;
                         }
                     }
                 }

--- a/crates/examples/common.rs
+++ b/crates/examples/common.rs
@@ -221,7 +221,7 @@ async fn start_consensus<
     };
 
     let consensus_metrics: ConsensusMetricsValue = match met.clone() {
-        Some(m) => ConsensusMetricsValue::new(&*m.clone()),
+        Some(m) => ConsensusMetricsValue::new(&*Arc::<PrometheusMetrics>::clone(&m)),
         None => ConsensusMetricsValue::default(),
     };
 
@@ -285,26 +285,20 @@ async fn start_consensus<
         start_rpc(rpc_port, tx_send.clone()).await;
     });
 
-    match met.clone() {
-        Some(m) => {
-            let metrics_cloned = m.clone();
-            tokio::spawn(async move {
-                let port = metrics_cloned.get_port();
-                match port {
-                    Some(port) => {
-                        tracing::info!("Starting metrics server on port {}", port);
-                        let bind_endpoint = SocketAddr::new(Ipv4Addr::new(0, 0, 0, 0).into(), port);
-                        serve_metrics(bind_endpoint, metrics_cloned.get_registry()).await;
-                    }
-                    None => {}
-                };
-            });
-        }
-        None => {}
+    if let Some(m)  = met.clone() {
+        let metrics_cloned = Arc::<PrometheusMetrics>::clone(&m);
+        tokio::spawn(async move {
+            let port = metrics_cloned.get_port();
+            if let Some(port) = port {
+                tracing::info!("Starting metrics server on port {}", port);
+                let bind_endpoint = SocketAddr::new(Ipv4Addr::new(0, 0, 0, 0).into(), port);
+                serve_metrics(bind_endpoint, metrics_cloned.get_registry()).await;
+            }
+        });
     }
 
     let metrics_cloned = match met.clone() {
-        Some(m) => m.clone(),
+        Some(m) => Arc::<PrometheusMetrics>::clone(&m),
         None => init_metrics(None, None),
     };
 
@@ -316,7 +310,7 @@ async fn start_consensus<
     // Spawn the task to wait for events
     let join_handle = tokio::spawn(async move {
         let mut metrics_interval = tokio::time::interval(Duration::from_secs(60));
-        let metrics = metrics_cloned.clone();
+        let metrics = Arc::<PrometheusMetrics>::clone(&metrics_cloned);
         // Get the event stream for this particular node
         let mut event_stream = handle.event_stream();
         // Wait for a `Decide` event for the view number we requested
@@ -329,10 +323,11 @@ async fn start_consensus<
                     tracing::info!("Metrics interval tick!");
                     let file_prefix = metrics.get_prefix();
                     let metrics_folder = metrics.get_folder().unwrap();
-                    match metrics.gather() {
-                        Some(collected_metrics) => flush_metrics(metrics_folder, file_prefix, collected_metrics),
-                        None => tracing::error!("Failed to gather metrics"),
-                    };
+                    if let Some(collected_metrics) = metrics.gather() { 
+                        flush_metrics(&metrics_folder, file_prefix, &collected_metrics);
+                    } else { 
+                        tracing::error!("Failed to gather metrics"); 
+                    }
                 }                
                 Some(tx) = tx_recv.recv() => {
                     // take the first transaction_size bytes of the transaction

--- a/crates/examples/common.rs
+++ b/crates/examples/common.rs
@@ -1,6 +1,5 @@
 use std::time::Instant;
 use std::net::Ipv4Addr;
-
 use async_lock::RwLock;
 use hotshot_types::{
     data::EpochNumber, traits::{node_implementation::ConsensusTime,metrics}, utils::non_crypto_hash, 
@@ -13,10 +12,10 @@ include!("rpc.rs");
 include!("metrics.rs");
 
 /// initialize prom metrics
-pub fn init_metrics(port: Option<u16>) -> Arc<PrometheusMetrics> {
+pub fn init_metrics(port: Option<u16>, metrics_folder: Option<String>) -> Arc<PrometheusMetrics> {
     // Create a new metrics instance
     let registry = prometheus::Registry::new();
-    let metrics = PrometheusMetrics::new_with_prefix(registry, port, "hotshot".to_string());
+    let metrics = PrometheusMetrics::new_with_prefix(registry, port, "hotshot".to_string(), metrics_folder);
     Arc::new(metrics)
 }
 
@@ -304,18 +303,37 @@ async fn start_consensus<
         None => {}
     }
 
-    let metrics_cloned = match met {
+    let metrics_cloned = match met.clone() {
         Some(m) => m.clone(),
-        None => init_metrics(None),
+        None => init_metrics(None, None),
     };
+
+    let flush_metrics_on = match met.clone() {
+        Some(m) => m.get_folder().is_some(),
+        None => false,
+    };
+
     // Spawn the task to wait for events
     let join_handle = tokio::spawn(async move {
+        let mut metrics_interval = tokio::time::interval(Duration::from_secs(60));
+        let metrics = metrics_cloned.clone();
         // Get the event stream for this particular node
         let mut event_stream = handle.event_stream();
-
         // Wait for a `Decide` event for the view number we requested
         loop {
             tokio::select! {
+                _ = metrics_interval.tick() => {
+                    if !flush_metrics_on {
+                        continue;
+                    }
+                    tracing::info!("Metrics interval tick!");
+                    let file_prefix = metrics.get_prefix();
+                    let metrics_folder = metrics.get_folder().unwrap();
+                    match metrics.gather() {
+                        Some(collected_metrics) => flush_metrics(metrics_folder, file_prefix, collected_metrics),
+                        None => tracing::error!("Failed to gather metrics"),
+                    };
+                }                
                 Some(tx) = tx_recv.recv() => {
                     // take the first transaction_size bytes of the transaction
                     let n = if tx.len() < transaction_size {
@@ -449,20 +467,6 @@ async fn start_consensus<
                                 // Break when we've decided on the view number we requested
                                 break;
                             }
-                        }
-
-                        if *qc.view_number % 100 == 0 {
-                            // print metrics every 100 views
-                            let collected_metrics = metrics_cloned.gather();
-                            match collected_metrics {
-                                Some(metrics) => {
-                                    println!("----\nMETRICS----\n{metrics}");
-                                }
-                                None => {
-                                    info!("No metrics collected");
-                                }
-                            }
-                            break;
                         }
                     }
                 }

--- a/crates/examples/common.rs
+++ b/crates/examples/common.rs
@@ -1,13 +1,24 @@
 use std::time::Instant;
+use std::net::Ipv4Addr;
 
 use async_lock::RwLock;
 use hotshot_types::{
-    data::EpochNumber, traits::node_implementation::ConsensusTime, utils::non_crypto_hash,
+    data::EpochNumber, traits::{node_implementation::ConsensusTime,metrics}, utils::non_crypto_hash, 
 };
 use simple_moving_average::SingleSumSMA;
 use simple_moving_average::SMA;
 
 include!("rpc.rs");
+
+include!("metrics.rs");
+
+/// initialize prom metrics
+pub fn init_metrics(port: Option<u16>) -> Arc<PrometheusMetrics> {
+    // Create a new metrics instance
+    let registry = prometheus::Registry::new();
+    let metrics = PrometheusMetrics::new_with_prefix(registry, port, "hotshot".to_string());
+    Arc::new(metrics)
+}
 
 /// The type of network to use for the example
 #[derive(Debug, PartialEq, Eq)]
@@ -82,6 +93,7 @@ async fn new_libp2p_network(
     public_key: &BLSPubKey,
     private_key: &BLSPrivKey,
     known_libp2p_nodes: &[Multiaddr],
+    met: Option<Arc<dyn metrics::Metrics>>,    
 ) -> Result<Arc<Libp2pNetwork<TestTypes>>> {
     // Derive the Libp2p keypair from the private key
     let libp2p_keypair = derive_libp2p_keypair::<BLSPubKey>(private_key)
@@ -115,12 +127,16 @@ async fn new_libp2p_network(
         },
     };
 
+    let m: Libp2pMetricsValue = match met {
+        Some(m) => Libp2pMetricsValue::new(&*m),
+        None => Libp2pMetricsValue::default(),
+    };
     // Create the network with the config
     Ok(Arc::new(
         Libp2pNetwork::new(
             libp2p_config,
             public_key,
-            Libp2pMetricsValue::default(),
+            m,
             None,
         )
         .await
@@ -136,7 +152,7 @@ async fn new_combined_network(
     known_libp2p_nodes: &[Multiaddr],
     is_da_node: bool,
     public_key: &BLSPubKey,
-    private_key: &BLSPrivKey,
+    private_key: &BLSPrivKey, 
 ) -> Result<Arc<hotshot::traits::implementations::CombinedNetworks<TestTypes>>> {
     // Create the CDN network and launch the CDN
     let cdn_network = Arc::into_inner(new_cdn_network(
@@ -155,6 +171,7 @@ async fn new_combined_network(
             public_key,
             private_key,
             known_libp2p_nodes,
+            None,
         )
         .await?,
     )
@@ -195,12 +212,18 @@ async fn start_consensus<
     _num_transactions_per_view: usize,
     transaction_size: usize,
     num_views: Option<usize>,
+    met: Option<Arc<PrometheusMetrics>>,
 ) -> Result<tokio::task::JoinHandle<()>> {
     // Create the marketplace config
     let marketplace_config: MarketplaceConfig<TestTypes, I> = MarketplaceConfig {
         auction_results_provider: TestAuctionResultsProvider::<TestTypes>::default().into(),
         // TODO: we need to pass a valid fallback builder url here somehow
         fallback_builder_url: Url::parse("http://localhost:8080").unwrap(),
+    };
+
+    let consensus_metrics: ConsensusMetricsValue = match met.clone() {
+        Some(m) => ConsensusMetricsValue::new(&*m.clone()),
+        None => ConsensusMetricsValue::default(),
     };
 
     // Initialize the system context
@@ -211,7 +234,7 @@ async fn start_consensus<
         Arc::new(RwLock::new(memberships.clone())),
         network,
         hotshot_initializer,
-        ConsensusMetricsValue::default(),
+        consensus_metrics,
         TestStorage::<TestTypes>::default(),
         marketplace_config,
     )
@@ -262,6 +285,24 @@ async fn start_consensus<
     tokio::spawn(async move {
         start_rpc(rpc_port, tx_send.clone()).await;
     });
+
+    match met {
+        Some(m) => {
+            let metrics_cloned = m.clone();
+            tokio::spawn(async move {
+                let port = metrics_cloned.get_port();
+                match port {
+                    Some(port) => {
+                        tracing::info!("Starting metrics server on port {}", port);
+                        let bind_endpoint = SocketAddr::new(Ipv4Addr::new(0, 0, 0, 0).into(), port);
+                        serve_metrics(bind_endpoint, metrics_cloned.get_registry()).await;
+                    }
+                    None => {}
+                };
+            });
+        }
+        None => {}
+    }
 
     // Spawn the task to wait for events
     let join_handle = tokio::spawn(async move {

--- a/crates/examples/metrics.rs
+++ b/crates/examples/metrics.rs
@@ -159,9 +159,16 @@ impl hsmetrics::MetricsFamily<Box<dyn hsmetrics::Histogram>> for PrometheusHisto
         None => "metrics".to_string(),
     };
     let timestamp = time::SystemTime::now().duration_since(time::UNIX_EPOCH).unwrap().as_secs();
-    let file = format!("{folder}/{file_prefix}_{timestamp}.prom");
-    tracing::info!("Writing metrics to file: {}", file);
-    match File::create(file) {
+    let file_path = format!("{folder}/{file_prefix}_{timestamp}.prom");
+    match std::fs::create_dir_all(folder.clone()) {
+        Ok(_) => tracing::info!("Successfully created metrics folder: {folder}"),
+        Err(e) => {
+            tracing::error!("Failed to create folder: {folder}: {e}");
+            return;
+        },
+    }
+    tracing::info!("Writing metrics to file: {file_path}");
+    match File::create(file_path) {
         Ok(mut f) => {
             match f.write_all(raw_metrics.as_bytes()) {
                 Ok(_) => {

--- a/crates/examples/metrics.rs
+++ b/crates/examples/metrics.rs
@@ -155,8 +155,8 @@ impl hsmetrics::MetricsFamily<Box<dyn hsmetrics::Histogram>> for PrometheusHisto
         return;
     }
     let file_prefix = match prefix {
-        Some(p) => format!("metrics_{p}_"),
-        None => "metrics_".to_string(),
+        Some(p) => format!("metrics_{p}"),
+        None => "metrics".to_string(),
     };
     let timestamp = time::SystemTime::now().duration_since(time::UNIX_EPOCH).unwrap().as_secs();
     let file = format!("{folder}/{file_prefix}_{timestamp}.prom");

--- a/crates/examples/metrics.rs
+++ b/crates/examples/metrics.rs
@@ -1,5 +1,7 @@
-use std::net::SocketAddr;
-
+use std::{net::SocketAddr, time};
+#[allow(unused_imports)]
+use std::io::Write as _;
+use std::fs::File;
 use hotshot_types::traits::metrics as hsmetrics;
 // use warp::Filter;
 
@@ -147,12 +149,36 @@ impl hsmetrics::MetricsFamily<Box<dyn hsmetrics::Histogram>> for PrometheusHisto
     }
 }
 
+ /// Flush the metrics to a file
+ pub fn flush_metrics(folder: String, prefix: Option<String>, raw_metrics: String) {
+    if raw_metrics.is_empty() {
+        return;
+    }
+    let file_prefix = match prefix {
+        Some(p) => format!("metrics_{p}_"),
+        None => "metrics_".to_string(),
+    };
+    let timestamp = time::SystemTime::now().duration_since(time::UNIX_EPOCH).unwrap().as_secs();
+    let file = format!("{folder}/{file_prefix}_{timestamp}.prom");
+    tracing::info!("Writing metrics to file: {}", file);
+    match File::create(file) {
+        Ok(mut f) => {
+            match f.write_all(raw_metrics.as_bytes()) {
+                Ok(_) => tracing::info!("Successfully wrote metrics to file"),
+                Err(e) => tracing::error!("Failed to write metrics to file: {}", e),
+            }
+        }
+        Err(e) => tracing::error!("Failed to create file: {}", e),
+    }
+}
+
 /// A metrics implementation that uses Prometheus as the backend
 #[derive(Debug, Clone, Default)]
 pub struct PrometheusMetrics {
     registry: prometheus::Registry,
     port: Option<u16>,
     prefix: Option<String>,
+    folder: Option<String>,
 }
 
 impl PrometheusMetrics {
@@ -162,6 +188,7 @@ impl PrometheusMetrics {
             registry: prometheus::Registry::new(),
             port: None,
             prefix: None,
+            folder: None,
         }
     }
 
@@ -170,11 +197,13 @@ impl PrometheusMetrics {
         registry: prometheus::Registry,
         port: Option<u16>,
         prefix: String,
+        folder: Option<String>,
     ) -> Self {
         Self {
             registry,
             port,
             prefix: Some(prefix),
+            folder,
         }
     }
 
@@ -193,6 +222,16 @@ impl PrometheusMetrics {
     /// Get the port the metrics server is running on
     pub fn get_port(&self) -> Option<u16> {
         self.port
+    }
+
+    /// Get the folder where the metrics are stored
+    pub fn get_folder(&self) -> Option<String> {
+        self.folder.clone()
+    }
+
+    /// Get the prefix/namespace for the metrics
+    pub fn get_prefix(&self) -> Option<String> {
+        self.prefix.clone()
     }
 
     /// Gather the metrics and return them as a string
@@ -285,7 +324,7 @@ impl hsmetrics::Metrics for PrometheusMetrics {
             Some(p) => format!("{p}_{subgroup_name}"),
             None => subgroup_name,
         };
-        Box::new(PrometheusMetrics::new_with_prefix(self.registry.clone(), self.port.clone(), prefix))
+        Box::new(PrometheusMetrics::new_with_prefix(self.registry.clone(), self.port.clone(), prefix, self.folder.clone()))
     }
 }
 

--- a/crates/examples/metrics.rs
+++ b/crates/examples/metrics.rs
@@ -14,12 +14,14 @@ pub struct PrometheusCounter {
 
 impl PrometheusCounter {
     /// Create a new Prometheus counter
+    #[must_use]
     pub fn new(counter: prometheus::Counter) -> Self {
         Self { counter }
     }
 }
 
 impl hsmetrics::Counter for PrometheusCounter {
+    #[allow(clippy::cast_precision_loss)]
     fn add(&self, amount: usize) {
         self.counter.inc_by(amount as f64);
     }
@@ -34,6 +36,7 @@ pub struct PrometheusCounterFamily {
 
 impl PrometheusCounterFamily {
     /// Create a new Prometheus counter family
+    #[must_use]
     pub fn new(counter_family: prometheus::CounterVec) -> Self {
         Self { counter_family }
     }
@@ -55,6 +58,7 @@ pub struct PrometheusGauge {
 
 impl PrometheusGauge {
     /// Create a new Prometheus gauge
+    #[must_use]
     pub fn new(gauge: prometheus::Gauge) -> Self {
         Self { gauge }
     }
@@ -62,11 +66,13 @@ impl PrometheusGauge {
 
 impl hsmetrics::Gauge for PrometheusGauge {
     /// Set the gauge value
+    #[allow(clippy::cast_precision_loss)]
     fn set(&self, value: usize) {
         self.gauge.set(value as f64);
     }
 
     /// Update the gauge value
+    #[allow(clippy::cast_precision_loss)]
     fn update(&self, delta: i64) {
         self.gauge.add(delta as f64);
     }
@@ -81,6 +87,7 @@ pub struct PrometheusGaugeFamily {
 
 impl PrometheusGaugeFamily {
     /// Create a new Prometheus gauge family
+    #[must_use]
     pub fn new(gauge_family: prometheus::GaugeVec) -> Self {
         Self { gauge_family }
     }
@@ -102,6 +109,7 @@ pub struct PrometheusTextGaugeFamily {
 
 impl PrometheusTextGaugeFamily {
     /// Create a new Prometheus gauge family
+    #[must_use]
     pub fn new(gauge_family: prometheus::GaugeVec) -> Self {
         Self { gauge_family }
     }
@@ -123,6 +131,7 @@ pub struct PrometheusHistogram {
 
 impl PrometheusHistogram {
     /// Create a new Prometheus histogram
+    #[must_use]
     pub fn new(histogram: prometheus::Histogram) -> Self {
         Self { histogram }
     }
@@ -143,6 +152,7 @@ pub struct PrometheusHistogramFamily {
 
 impl PrometheusHistogramFamily {
     /// Create a new Prometheus histogram family
+    #[must_use]
     pub fn new(histogram_family: prometheus::HistogramVec) -> Self {
         Self { histogram_family }
     }
@@ -208,6 +218,7 @@ pub struct PrometheusMetrics {
 
 impl PrometheusMetrics {
     /// Create a new Prometheus metrics instance
+    #[must_use]
     pub fn new() -> Self {
         Self {
             registry: prometheus::Registry::new(),
@@ -218,6 +229,7 @@ impl PrometheusMetrics {
     }
 
     /// Create a new Prometheus metrics instance with a prefix/namespace
+    #[must_use]
     pub fn new_with_prefix(
         registry: prometheus::Registry,
         port: Option<u16>,
@@ -233,6 +245,7 @@ impl PrometheusMetrics {
     }
 
     /// Get the name of the metric with the prefix
+    #[must_use]
     fn get_name(&self, name: String) -> String {
         match &self.prefix {
             Some(p) => format!("{p}_{name}"),
@@ -241,26 +254,31 @@ impl PrometheusMetrics {
     }
 
     /// Get the Prometheus registry
+    #[must_use]
     pub fn get_registry(&self) -> prometheus::Registry {
         self.registry.clone()
     }
 
     /// Get the port the metrics server is running on
+    #[must_use]
     pub fn get_port(&self) -> Option<u16> {
         self.port
     }
 
     /// Get the folder where the metrics are stored
+    #[must_use]
     pub fn get_folder(&self) -> Option<String> {
         self.folder.clone()
     }
 
     /// Get the prefix/namespace for the metrics
+    #[must_use]
     pub fn get_prefix(&self) -> Option<String> {
         self.prefix.clone()
     }
 
     /// Gather the metrics and return them as a string
+    #[must_use]
     pub fn gather(&self) -> Option<String> {
         let encoder = prometheus::TextEncoder::new();
         let metric_families = self.registry.gather();

--- a/crates/examples/metrics.rs
+++ b/crates/examples/metrics.rs
@@ -164,7 +164,14 @@ impl hsmetrics::MetricsFamily<Box<dyn hsmetrics::Histogram>> for PrometheusHisto
     match File::create(file) {
         Ok(mut f) => {
             match f.write_all(raw_metrics.as_bytes()) {
-                Ok(_) => tracing::info!("Successfully wrote metrics to file"),
+                Ok(_) => {
+                    tracing::info!("Successfully wrote metrics to file");
+                    // flush/close file
+                    match f.sync_all() {
+                        Ok(_) => (),
+                        Err(e) => tracing::error!("Failed to flush metrics to file: {}", e),
+                    }
+                },
                 Err(e) => tracing::error!("Failed to write metrics to file: {}", e),
             }
         }

--- a/crates/examples/metrics.rs
+++ b/crates/examples/metrics.rs
@@ -8,6 +8,7 @@ use hotshot_types::traits::metrics as hsmetrics;
 /// A counter metric wrapper around the Prometheus Counter
 #[derive(Debug, Clone)]
 pub struct PrometheusCounter {
+    /// The Prometheus counter
     counter: prometheus::Counter,
 }
 
@@ -27,6 +28,7 @@ impl hsmetrics::Counter for PrometheusCounter {
 /// A counter family metric wrapper around the Prometheus CounterVec
 #[derive(Debug, Clone)]
 pub struct PrometheusCounterFamily {
+    /// The Prometheus counter family
     counter_family: prometheus::CounterVec,
 }
 
@@ -39,7 +41,7 @@ impl PrometheusCounterFamily {
 
 impl hsmetrics::MetricsFamily<Box<dyn hsmetrics::Counter>> for PrometheusCounterFamily {
     fn create(&self, labels: Vec<String>) -> Box<dyn hsmetrics::Counter> {
-        let vals: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+        let vals: Vec<&str> = labels.iter().map(std::string::String::as_str).collect();
         Box::new(PrometheusCounter::new(self.counter_family.with_label_values(&vals)))
     }
 }
@@ -47,6 +49,7 @@ impl hsmetrics::MetricsFamily<Box<dyn hsmetrics::Counter>> for PrometheusCounter
 /// A gauge metric wrapper around the Prometheus Gauge
 #[derive(Debug, Clone)]
 pub struct PrometheusGauge {
+    /// The Prometheus gauge
     gauge: prometheus::Gauge,
 }
 
@@ -72,6 +75,7 @@ impl hsmetrics::Gauge for PrometheusGauge {
 /// A gauge family metric wrapper around the Prometheus GaugeVec
 #[derive(Debug, Clone)]
 pub struct PrometheusGaugeFamily {
+    /// The Prometheus gauge family
     gauge_family: prometheus::GaugeVec,
 }
 
@@ -84,7 +88,7 @@ impl PrometheusGaugeFamily {
 
 impl hsmetrics::MetricsFamily<Box<dyn hsmetrics::Gauge>> for PrometheusGaugeFamily {
     fn create(&self, labels: Vec<String>) -> Box<dyn hsmetrics::Gauge> {
-        let vals: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+        let vals: Vec<&str> = labels.iter().map(std::string::String::as_str).collect();
         Box::new(PrometheusGauge::new(self.gauge_family.with_label_values(&vals)))
     }
 }
@@ -92,6 +96,7 @@ impl hsmetrics::MetricsFamily<Box<dyn hsmetrics::Gauge>> for PrometheusGaugeFami
 /// A histogram metric wrapper around the Prometheus Histogram
 #[derive(Debug, Clone)]
 pub struct PrometheusTextGaugeFamily {
+    /// The Prometheus gauge family
     gauge_family: prometheus::GaugeVec,
 }
 
@@ -103,16 +108,16 @@ impl PrometheusTextGaugeFamily {
 }
 
 impl hsmetrics::MetricsFamily<()> for PrometheusTextGaugeFamily {
-    fn create(&self, labels: Vec<String>) -> () {
-        let vals: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+    fn create(&self, labels: Vec<String>) {
+        let vals: Vec<&str> = labels.iter().map(std::string::String::as_str).collect();
         self.gauge_family.with_label_values(&vals).set(1.0);
-        ()
     }
 }
 
 /// A histogram metric wrapper around the Prometheus Histogram
 #[derive(Debug, Clone)]
 pub struct PrometheusHistogram {
+    /// The Prometheus histogram
     histogram: prometheus::Histogram,
 }
 
@@ -132,6 +137,7 @@ impl hsmetrics::Histogram for PrometheusHistogram {
 /// A histogram family metric wrapper around the Prometheus HistogramVec
 #[derive(Debug, Clone)]
 pub struct PrometheusHistogramFamily {
+    /// The Prometheus histogram family
     histogram_family: prometheus::HistogramVec,
 }
 
@@ -144,13 +150,14 @@ impl PrometheusHistogramFamily {
 
 impl hsmetrics::MetricsFamily<Box<dyn hsmetrics::Histogram>> for PrometheusHistogramFamily {
     fn create(&self, labels: Vec<String>) -> Box<dyn hsmetrics::Histogram> {
-        let vals: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+        let vals: Vec<&str> = labels.iter().map(std::string::String::as_str).collect();
         Box::new(PrometheusHistogram::new(self.histogram_family.with_label_values(&vals)))
     }
 }
 
  /// Flush the metrics to a file
- pub fn flush_metrics(folder: String, prefix: Option<String>, raw_metrics: String) {
+ #[allow(clippy::missing_panics_doc)]
+ pub fn flush_metrics(folder: &str, prefix: Option<String>, raw_metrics: &str) {
     if raw_metrics.is_empty() {
         return;
     }
@@ -160,8 +167,8 @@ impl hsmetrics::MetricsFamily<Box<dyn hsmetrics::Histogram>> for PrometheusHisto
     };
     let timestamp = time::SystemTime::now().duration_since(time::UNIX_EPOCH).unwrap().as_secs();
     let file_path = format!("{folder}/{file_prefix}_{timestamp}.prom");
-    match std::fs::create_dir_all(folder.clone()) {
-        Ok(_) => tracing::info!("Successfully created metrics folder: {folder}"),
+    match std::fs::create_dir_all(folder) {
+       Ok(()) => tracing::info!("Successfully created metrics folder: {folder}"),
         Err(e) => {
             tracing::error!("Failed to create folder: {folder}: {e}");
             return;
@@ -171,11 +178,11 @@ impl hsmetrics::MetricsFamily<Box<dyn hsmetrics::Histogram>> for PrometheusHisto
     match File::create(file_path) {
         Ok(mut f) => {
             match f.write_all(raw_metrics.as_bytes()) {
-                Ok(_) => {
+                Ok(()) => {
                     tracing::info!("Successfully wrote metrics to file");
                     // flush/close file
                     match f.sync_all() {
-                        Ok(_) => (),
+                       Ok(()) => (),
                         Err(e) => tracing::error!("Failed to flush metrics to file: {}", e),
                     }
                 },
@@ -189,9 +196,13 @@ impl hsmetrics::MetricsFamily<Box<dyn hsmetrics::Histogram>> for PrometheusHisto
 /// A metrics implementation that uses Prometheus as the backend
 #[derive(Debug, Clone, Default)]
 pub struct PrometheusMetrics {
+    /// The Prometheus registry
     registry: prometheus::Registry,
+    /// The port the metrics server is running on
     port: Option<u16>,
+    /// The prefix/namespace for the metrics
     prefix: Option<String>,
+    /// The folder where the metrics are stored
     folder: Option<String>,
 }
 
@@ -221,6 +232,7 @@ impl PrometheusMetrics {
         }
     }
 
+    /// Get the name of the metric with the prefix
     fn get_name(&self, name: String) -> String {
         match &self.prefix {
             Some(p) => format!("{p}_{name}"),
@@ -291,7 +303,7 @@ impl hsmetrics::Metrics for PrometheusMetrics {
 
     fn counter_family(&self, name: String, labels: Vec<String>) -> Box<dyn hsmetrics::CounterFamily> {
         let formatted_name = self.get_name(name.clone());
-        let vals: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+        let vals: Vec<&str> = labels.iter().map(std::string::String::as_str).collect();
         let counter_vec = prometheus::CounterVec::new(
             prometheus::Opts::new(formatted_name, format!("Counter family for {name}")),
             &vals,
@@ -302,7 +314,7 @@ impl hsmetrics::Metrics for PrometheusMetrics {
 
     fn gauge_family(&self, name: String, labels: Vec<String>) -> Box<dyn hsmetrics::GaugeFamily> {
         let formatted_name = self.get_name(name.clone());
-        let vals: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+        let vals: Vec<&str> = labels.iter().map(std::string::String::as_str).collect();
         let gauge_vec = prometheus::GaugeVec::new(
             prometheus::Opts::new(formatted_name, format!("Gauge family for {name}")),
             &vals,
@@ -313,7 +325,7 @@ impl hsmetrics::Metrics for PrometheusMetrics {
 
     fn histogram_family(&self, name: String, labels: Vec<String>) -> Box<dyn hsmetrics::HistogramFamily> {
         let formatted_name = self.get_name(name.clone());
-        let vals: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+        let vals: Vec<&str> = labels.iter().map(std::string::String::as_str).collect();
         let histogram_vec = prometheus::HistogramVec::new(
             prometheus::HistogramOpts::new(formatted_name, format!("Histogram family for {name}")).buckets(vec![1.0, 2.0, 3.0, 4.0, 5.0, 7.5, 10.0]),
             &vals,
@@ -324,7 +336,7 @@ impl hsmetrics::Metrics for PrometheusMetrics {
 
     fn text_family(&self, name: String, labels: Vec<String>) -> Box<dyn hsmetrics::TextFamily> {
         let formatted_name = self.get_name(name.clone());
-        let vals: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+        let vals: Vec<&str> = labels.iter().map(std::string::String::as_str).collect();
         let gauge_vec = prometheus::GaugeVec::new(
             prometheus::Opts::new(formatted_name, format!("Gauge family for {name}")),
             &vals,
@@ -338,7 +350,7 @@ impl hsmetrics::Metrics for PrometheusMetrics {
             Some(p) => format!("{p}_{subgroup_name}"),
             None => subgroup_name,
         };
-        Box::new(PrometheusMetrics::new_with_prefix(self.registry.clone(), self.port.clone(), prefix, self.folder.clone()))
+        Box::new(PrometheusMetrics::new_with_prefix(self.registry.clone(), self.port, prefix, self.folder.clone()))
     }
 }
 

--- a/crates/examples/metrics.rs
+++ b/crates/examples/metrics.rs
@@ -194,6 +194,17 @@ impl PrometheusMetrics {
     pub fn get_port(&self) -> Option<u16> {
         self.port
     }
+
+    /// Gather the metrics and return them as a string
+    pub fn gather(&self) -> Option<String> {
+        let encoder = prometheus::TextEncoder::new();
+        let metric_families = self.registry.gather();
+
+        match encoder.encode_to_string(&metric_families) {
+            Ok(raw) => Some(raw),
+            Err(_) => None,
+        }
+    }
 }
 
 impl hsmetrics::Metrics for PrometheusMetrics {

--- a/crates/examples/metrics.rs
+++ b/crates/examples/metrics.rs
@@ -1,0 +1,301 @@
+use std::net::SocketAddr;
+
+use hotshot_types::traits::metrics as hsmetrics;
+// use warp::Filter;
+
+/// A counter metric wrapper around the Prometheus Counter
+#[derive(Debug, Clone)]
+pub struct PrometheusCounter {
+    counter: prometheus::Counter,
+}
+
+impl PrometheusCounter {
+    /// Create a new Prometheus counter
+    pub fn new(counter: prometheus::Counter) -> Self {
+        Self { counter }
+    }
+}
+
+impl hsmetrics::Counter for PrometheusCounter {
+    fn add(&self, amount: usize) {
+        self.counter.inc_by(amount as f64);
+    }
+}
+
+/// A counter family metric wrapper around the Prometheus CounterVec
+#[derive(Debug, Clone)]
+pub struct PrometheusCounterFamily {
+    counter_family: prometheus::CounterVec,
+}
+
+impl PrometheusCounterFamily {
+    /// Create a new Prometheus counter family
+    pub fn new(counter_family: prometheus::CounterVec) -> Self {
+        Self { counter_family }
+    }
+}
+
+impl hsmetrics::MetricsFamily<Box<dyn hsmetrics::Counter>> for PrometheusCounterFamily {
+    fn create(&self, labels: Vec<String>) -> Box<dyn hsmetrics::Counter> {
+        let vals: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+        Box::new(PrometheusCounter::new(self.counter_family.with_label_values(&vals)))
+    }
+}
+
+/// A gauge metric wrapper around the Prometheus Gauge
+#[derive(Debug, Clone)]
+pub struct PrometheusGauge {
+    gauge: prometheus::Gauge,
+}
+
+impl PrometheusGauge {
+    /// Create a new Prometheus gauge
+    pub fn new(gauge: prometheus::Gauge) -> Self {
+        Self { gauge }
+    }
+}
+
+impl hsmetrics::Gauge for PrometheusGauge {
+    /// Set the gauge value
+    fn set(&self, value: usize) {
+        self.gauge.set(value as f64);
+    }
+
+    /// Update the gauge value
+    fn update(&self, delta: i64) {
+        self.gauge.add(delta as f64);
+    }
+}
+
+/// A gauge family metric wrapper around the Prometheus GaugeVec
+#[derive(Debug, Clone)]
+pub struct PrometheusGaugeFamily {
+    gauge_family: prometheus::GaugeVec,
+}
+
+impl PrometheusGaugeFamily {
+    /// Create a new Prometheus gauge family
+    pub fn new(gauge_family: prometheus::GaugeVec) -> Self {
+        Self { gauge_family }
+    }
+}
+
+impl hsmetrics::MetricsFamily<Box<dyn hsmetrics::Gauge>> for PrometheusGaugeFamily {
+    fn create(&self, labels: Vec<String>) -> Box<dyn hsmetrics::Gauge> {
+        let vals: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+        Box::new(PrometheusGauge::new(self.gauge_family.with_label_values(&vals)))
+    }
+}
+
+/// A histogram metric wrapper around the Prometheus Histogram
+#[derive(Debug, Clone)]
+pub struct PrometheusTextGaugeFamily {
+    gauge_family: prometheus::GaugeVec,
+}
+
+impl PrometheusTextGaugeFamily {
+    /// Create a new Prometheus gauge family
+    pub fn new(gauge_family: prometheus::GaugeVec) -> Self {
+        Self { gauge_family }
+    }
+}
+
+impl hsmetrics::MetricsFamily<()> for PrometheusTextGaugeFamily {
+    fn create(&self, labels: Vec<String>) -> () {
+        let vals: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+        self.gauge_family.with_label_values(&vals).set(1.0);
+        ()
+    }
+}
+
+/// A histogram metric wrapper around the Prometheus Histogram
+#[derive(Debug, Clone)]
+pub struct PrometheusHistogram {
+    histogram: prometheus::Histogram,
+}
+
+impl PrometheusHistogram {
+    /// Create a new Prometheus histogram
+    pub fn new(histogram: prometheus::Histogram) -> Self {
+        Self { histogram }
+    }
+}
+
+impl hsmetrics::Histogram for PrometheusHistogram {
+    fn add_point(&self, point: f64) {
+        self.histogram.observe(point);
+    }
+}
+
+/// A histogram family metric wrapper around the Prometheus HistogramVec
+#[derive(Debug, Clone)]
+pub struct PrometheusHistogramFamily {
+    histogram_family: prometheus::HistogramVec,
+}
+
+impl PrometheusHistogramFamily {
+    /// Create a new Prometheus histogram family
+    pub fn new(histogram_family: prometheus::HistogramVec) -> Self {
+        Self { histogram_family }
+    }
+}
+
+impl hsmetrics::MetricsFamily<Box<dyn hsmetrics::Histogram>> for PrometheusHistogramFamily {
+    fn create(&self, labels: Vec<String>) -> Box<dyn hsmetrics::Histogram> {
+        let vals: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+        Box::new(PrometheusHistogram::new(self.histogram_family.with_label_values(&vals)))
+    }
+}
+
+/// A metrics implementation that uses Prometheus as the backend
+#[derive(Debug, Clone, Default)]
+pub struct PrometheusMetrics {
+    registry: prometheus::Registry,
+    port: Option<u16>,
+    prefix: Option<String>,
+}
+
+impl PrometheusMetrics {
+    /// Create a new Prometheus metrics instance
+    pub fn new() -> Self {
+        Self {
+            registry: prometheus::Registry::new(),
+            port: None,
+            prefix: None,
+        }
+    }
+
+    /// Create a new Prometheus metrics instance with a prefix/namespace
+    pub fn new_with_prefix(
+        registry: prometheus::Registry,
+        port: Option<u16>,
+        prefix: String,
+    ) -> Self {
+        Self {
+            registry,
+            port,
+            prefix: Some(prefix),
+        }
+    }
+
+    fn get_name(&self, name: String) -> String {
+        match &self.prefix {
+            Some(p) => format!("{p}_{name}"),
+            None => name,
+        }
+    }
+
+    /// Get the Prometheus registry
+    pub fn get_registry(&self) -> prometheus::Registry {
+        self.registry.clone()
+    }
+
+    /// Get the port the metrics server is running on
+    pub fn get_port(&self) -> Option<u16> {
+        self.port
+    }
+}
+
+impl hsmetrics::Metrics for PrometheusMetrics {
+    fn create_counter(&self, name: String, _unit_label: Option<String>) -> Box<dyn hsmetrics::Counter> {
+        let formatted_name = self.get_name(name.clone());
+        let counter = prometheus::Counter::new(formatted_name, format!("Counter for {name}")).unwrap();
+        self.registry.register(Box::new(counter.clone())).unwrap();
+        Box::new(PrometheusCounter::new(counter))
+    }
+
+    fn create_gauge(&self, name: String, _unit_label: Option<String>) -> Box<dyn hsmetrics::Gauge> {
+        let formatted_name = self.get_name(name.clone());
+        let gauge = prometheus::Gauge::new(formatted_name, format!("Gauge for {name}")).unwrap();
+        self.registry.register(Box::new(gauge.clone())).unwrap();
+        Box::new(PrometheusGauge::new(gauge))
+    }
+
+    fn create_histogram(&self, name: String, _unit_label: Option<String>) -> Box<dyn hsmetrics::Histogram> {
+        let formatted_name = self.get_name(name.clone());
+        let histogram = prometheus::Histogram::with_opts(prometheus::HistogramOpts::new(formatted_name, format!("Histogram for {name}")).buckets(vec![1.0, 2.0, 3.0, 4.0, 5.0, 7.5, 10.0])).unwrap();
+        self.registry.register(Box::new(histogram.clone())).unwrap();
+        Box::new(PrometheusHistogram::new(histogram))
+    }
+
+    fn create_text(&self, name: String) {
+        let formatted_name = self.get_name(name.clone());
+        let gauge = prometheus::Gauge::new(formatted_name, format!("Gauge for {name}")).unwrap();
+        self.registry.register(Box::new(gauge.clone())).unwrap();
+        gauge.set(1.0);
+    }
+
+    fn counter_family(&self, name: String, labels: Vec<String>) -> Box<dyn hsmetrics::CounterFamily> {
+        let formatted_name = self.get_name(name.clone());
+        let vals: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+        let counter_vec = prometheus::CounterVec::new(
+            prometheus::Opts::new(formatted_name, format!("Counter family for {name}")),
+            &vals,
+        ).unwrap();
+        self.registry.register(Box::new(counter_vec.clone())).unwrap();
+        Box::new(PrometheusCounterFamily::new(counter_vec))
+    }
+
+    fn gauge_family(&self, name: String, labels: Vec<String>) -> Box<dyn hsmetrics::GaugeFamily> {
+        let formatted_name = self.get_name(name.clone());
+        let vals: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+        let gauge_vec = prometheus::GaugeVec::new(
+            prometheus::Opts::new(formatted_name, format!("Gauge family for {name}")),
+            &vals,
+        ).unwrap();
+        self.registry.register(Box::new(gauge_vec.clone())).unwrap();
+        Box::new(PrometheusGaugeFamily::new(gauge_vec))
+    }
+
+    fn histogram_family(&self, name: String, labels: Vec<String>) -> Box<dyn hsmetrics::HistogramFamily> {
+        let formatted_name = self.get_name(name.clone());
+        let vals: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+        let histogram_vec = prometheus::HistogramVec::new(
+            prometheus::HistogramOpts::new(formatted_name, format!("Histogram family for {name}")).buckets(vec![1.0, 2.0, 3.0, 4.0, 5.0, 7.5, 10.0]),
+            &vals,
+        ).unwrap();
+        self.registry.register(Box::new(histogram_vec.clone())).unwrap();
+        Box::new(PrometheusHistogramFamily::new(histogram_vec)) 
+    }
+
+    fn text_family(&self, name: String, labels: Vec<String>) -> Box<dyn hsmetrics::TextFamily> {
+        let formatted_name = self.get_name(name.clone());
+        let vals: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+        let gauge_vec = prometheus::GaugeVec::new(
+            prometheus::Opts::new(formatted_name, format!("Gauge family for {name}")),
+            &vals,
+        ).unwrap();
+        self.registry.register(Box::new(gauge_vec.clone())).unwrap();
+        Box::new(PrometheusTextGaugeFamily::new(gauge_vec))
+    }
+
+    fn subgroup(&self, subgroup_name: String) -> Box<dyn hsmetrics::Metrics> {
+        let prefix = match &self.prefix {
+            Some(p) => format!("{p}_{subgroup_name}"),
+            None => subgroup_name,
+        };
+        Box::new(PrometheusMetrics::new_with_prefix(self.registry.clone(), self.port.clone(), prefix))
+    }
+}
+
+/// Start the metrics server that should run forever on a particular port
+pub async fn serve_metrics(bind_endpoint: SocketAddr, prom_registry: prometheus::Registry) {
+    let prom_filter = warp::any().map(move || prom_registry.clone());
+    // The `/metrics` route is standard for Prometheus deployments
+    let route = warp::path("metrics")
+        .and(prom_filter)
+        .and_then( |prom_registry: prometheus::Registry| async move {
+            tracing::debug!("Serving metrics");
+            // Gather all metrics, encode them, and return them.
+            let encoder = prometheus::TextEncoder::new();
+            let metric_families = prom_registry.gather();
+
+            match encoder.encode_to_string(&metric_families) {
+                Ok(raw) => Ok(warp::reply::html(raw)),
+                Err(_) => Err(warp::reject()),
+            }
+        });
+
+    // Serve the route on the specified port
+    warp::serve(route).run(bind_endpoint).await;
+}

--- a/crates/examples/single-validator.rs
+++ b/crates/examples/single-validator.rs
@@ -5,7 +5,7 @@
 //! real builder is in an upstream repo)
 
 use std::{
-    collections::HashMap, net::IpAddr, num::NonZero, str::FromStr, sync::Arc, time::Duration,
+    collections::HashMap, io::Write, net::IpAddr, num::NonZero, str::FromStr, sync::Arc, time::Duration
 };
 
 use anyhow::{Context, Result};
@@ -104,6 +104,12 @@ struct Args {
     /// NOTE: This is only used for the libp2p network
     #[arg(long)]
     metrics_port: Option<u16>,
+
+    /// The file to write metrics to
+    /// If not specified, metrics are not written to a file
+    /// NOTE: This is only used for the libp2p network
+    #[arg(long)]
+    metrics_file: Option<String>,
 }
 
 /// Get the IP address to use based on the source
@@ -337,12 +343,29 @@ async fn main() -> Result<()> {
                 args.num_transactions_per_view,
                 args.transaction_size,
                 args.num_views,
-                met,
+                met.clone(),
             )
             .await?;
 
             // Wait for consensus to finish
             join_handle.await?;
+
+            match m.gather() {
+                Some(collected_metrics) => {
+                    match args.metrics_file {
+                        Some(file) => {
+                            let mut file = std::fs::File::create(file)?;
+                            file.write_all(collected_metrics.as_bytes())?; 
+                        }
+                        None => {
+                            println!("----\nMETRICS----\n{collected_metrics}");
+                        }
+                    }
+                }
+                None => {
+                    tracing::error!("Failed to gather metrics");
+                }
+            }
         }
         NetworkType::Combined => {
             // Create the network

--- a/crates/examples/single-validator.rs
+++ b/crates/examples/single-validator.rs
@@ -5,7 +5,8 @@
 //! real builder is in an upstream repo)
 
 use std::{
-    collections::HashMap, io::Write, net::IpAddr, num::NonZero, str::FromStr, sync::Arc, time::Duration
+    collections::HashMap, io::Write, net::IpAddr, num::NonZero, str::FromStr, sync::Arc,
+    time::Duration,
 };
 
 use anyhow::{Context, Result};
@@ -351,17 +352,15 @@ async fn main() -> Result<()> {
             join_handle.await?;
 
             match m.gather() {
-                Some(collected_metrics) => {
-                    match args.metrics_file {
-                        Some(file) => {
-                            let mut file = std::fs::File::create(file)?;
-                            file.write_all(collected_metrics.as_bytes())?; 
-                        }
-                        None => {
-                            println!("----\nMETRICS----\n{collected_metrics}");
-                        }
+                Some(collected_metrics) => match args.metrics_file {
+                    Some(file) => {
+                        let mut file = std::fs::File::create(file)?;
+                        file.write_all(collected_metrics.as_bytes())?;
                     }
-                }
+                    None => {
+                        println!("----\nMETRICS----\n{collected_metrics}");
+                    }
+                },
                 None => {
                     tracing::error!("Failed to gather metrics");
                 }

--- a/crates/examples/single-validator.rs
+++ b/crates/examples/single-validator.rs
@@ -98,6 +98,12 @@ struct Args {
     /// "combined", "cdn", or "libp2p"
     #[arg(long, default_value = "combined")]
     network: String,
+
+    /// The port to use for exposing metrics
+    /// If not specified, metrics are not exposed
+    /// NOTE: This is only used for the libp2p network
+    #[arg(long)]
+    metrics_port: Option<u16>,
 }
 
 /// Get the IP address to use based on the source
@@ -290,6 +296,7 @@ async fn main() -> Result<()> {
                 args.num_transactions_per_view,
                 args.transaction_size,
                 args.num_views,
+                None,
             )
             .await?;
 
@@ -297,6 +304,7 @@ async fn main() -> Result<()> {
             join_handle.await?;
         }
         NetworkType::LibP2P => {
+            let m = init_metrics(args.metrics_port);
             // Create the network
             let network = new_libp2p_network(
                 bind_multiaddr,
@@ -304,12 +312,17 @@ async fn main() -> Result<()> {
                 &public_key,
                 &private_key,
                 &known_libp2p_nodes,
+                Some(m.clone()),
             )
             .await
             .with_context(|| "Failed to create libp2p network")?;
 
             tracing::info!("Libp2p network created");
 
+            let met = match args.metrics_port {
+                Some(_) => Some(m.clone()),
+                None => None,
+            };
             // Start consensus
             let join_handle = start_consensus::<Libp2pImpl>(
                 public_key,
@@ -324,6 +337,7 @@ async fn main() -> Result<()> {
                 args.num_transactions_per_view,
                 args.transaction_size,
                 args.num_views,
+                met,
             )
             .await?;
 
@@ -358,6 +372,7 @@ async fn main() -> Result<()> {
                 args.num_transactions_per_view,
                 args.transaction_size,
                 args.num_views,
+                None,
             )
             .await?;
 

--- a/crates/examples/single-validator.rs
+++ b/crates/examples/single-validator.rs
@@ -106,11 +106,11 @@ struct Args {
     #[arg(long)]
     metrics_port: Option<u16>,
 
-    /// The file to write metrics to
-    /// If not specified, metrics are not written to a file
+    /// The folder to write metrics to, e.g. '/var/logs/metrics_hotshot'
+    /// If not specified, metrics are not flushed to file system
     /// NOTE: This is only used for the libp2p network
     #[arg(long)]
-    metrics_file: Option<String>,
+    metrics_dir: Option<String>,
 }
 
 /// Get the IP address to use based on the source
@@ -311,7 +311,7 @@ async fn main() -> Result<()> {
             join_handle.await?;
         }
         NetworkType::LibP2P => {
-            let m = init_metrics(args.metrics_port);
+            let m = init_metrics(args.metrics_port, args.metrics_dir.clone());
             // Create the network
             let network = new_libp2p_network(
                 bind_multiaddr,
@@ -351,20 +351,22 @@ async fn main() -> Result<()> {
             // Wait for consensus to finish
             join_handle.await?;
 
+            tracing::info!("Exiting libp2p network");
             match m.gather() {
-                Some(collected_metrics) => match args.metrics_file {
-                    Some(file) => {
-                        let mut file = std::fs::File::create(file)?;
-                        file.write_all(collected_metrics.as_bytes())?;
+                Some(collected_metrics) => match args.metrics_dir {
+                    Some(metrics_folder) => {
+                        flush_metrics(
+                            metrics_folder,
+                            Some("hotshot".to_string()),
+                            collected_metrics,
+                        );
                     }
-                    None => {
-                        println!("----\nMETRICS----\n{collected_metrics}");
-                    }
+                    None => {}
                 },
                 None => {
                     tracing::error!("Failed to gather metrics");
                 }
-            }
+            };
         }
         NetworkType::Combined => {
             // Create the network

--- a/crates/examples/single-validator.rs
+++ b/crates/examples/single-validator.rs
@@ -319,17 +319,14 @@ async fn main() -> Result<()> {
                 &public_key,
                 &private_key,
                 &known_libp2p_nodes,
-                Some(m.clone()),
+                Some(Arc::<PrometheusMetrics>::clone(&m)),
             )
             .await
             .with_context(|| "Failed to create libp2p network")?;
 
             tracing::info!("Libp2p network created");
 
-            let met = match args.metrics_port {
-                Some(_) => Some(m.clone()),
-                None => None,
-            };
+            let met = args.metrics_port.map(|_| Arc::<PrometheusMetrics>::clone(&m));
             // Start consensus
             let join_handle = start_consensus::<Libp2pImpl>(
                 public_key,
@@ -353,15 +350,14 @@ async fn main() -> Result<()> {
 
             tracing::info!("Exiting libp2p network");
             match m.gather() {
-                Some(collected_metrics) => match args.metrics_dir {
-                    Some(metrics_folder) => {
+                Some(collected_metrics) => {
+                    if let Some(metrics_folder) = args.metrics_dir {
                         flush_metrics(
-                            metrics_folder,
+                            &metrics_folder,
                             Some("hotshot".to_string()),
-                            collected_metrics,
+                            &collected_metrics,
                         );
                     }
-                    None => {}
                 },
                 None => {
                     tracing::error!("Failed to gather metrics");

--- a/crates/examples/single-validator.rs
+++ b/crates/examples/single-validator.rs
@@ -326,7 +326,9 @@ async fn main() -> Result<()> {
 
             tracing::info!("Libp2p network created");
 
-            let met = args.metrics_port.map(|_| Arc::<PrometheusMetrics>::clone(&m));
+            let met = args
+                .metrics_port
+                .map(|_| Arc::<PrometheusMetrics>::clone(&m));
             // Start consensus
             let join_handle = start_consensus::<Libp2pImpl>(
                 public_key,
@@ -358,7 +360,7 @@ async fn main() -> Result<()> {
                             &collected_metrics,
                         );
                     }
-                },
+                }
                 None => {
                     tracing::error!("Failed to gather metrics");
                 }


### PR DESCRIPTION
- added prometheus module that implements the `Metrics` trait
- flush metrics every `metrics_interval` (1m, not configurable at the moment) into `metrics_dir`
- added the option to serve prom metrics on http with `metrics_port`