### PR TITLE
Added rpc + validator metrics

### DIFF
--- a/crates/examples/common.rs
+++ b/crates/examples/common.rs
@@ -11,6 +11,43 @@ include!("rpc.rs");
 
 include!("metrics.rs");
 
+/// Validator-specific metrics
+#[derive(Clone, Debug)]
+pub struct ValidatorMetricsValue {
+    /// The number of blocks proposed by the validator 
+    pub num_block_proposed: Box<dyn Counter>,
+    /// The number of bytes in the blocks proposed by the validator
+    pub num_block_size_proposed: Box<dyn Counter>,
+    /// The number of transactions proposed by the validator    
+    pub num_tx_proposed: Box<dyn Counter>,
+    /// The number of transactions submitted by the validator
+    pub num_tx_submitted: Box<dyn Counter>,
+    /// The number of of failed submit attempts
+    pub num_tx_submit_fail: Box<dyn Counter>,
+}
+
+impl ValidatorMetricsValue {
+    /// Populate the metrics with Validator-specific metrics
+    pub fn new(metrics: &dyn Metrics) -> Self {
+        let subgroup = metrics.subgroup("validator".into());
+        Self {
+            num_block_proposed: subgroup.create_counter("num_block_proposed".into(), None),
+            num_block_size_proposed: subgroup.create_counter("num_block_size_proposed".into(), None),
+            num_tx_proposed: subgroup.create_counter("num_tx_proposed".into(), None),
+            num_tx_submitted: subgroup.create_counter("num_tx_submitted".into(), None),
+            num_tx_submit_fail: subgroup.create_counter("num_tx_submit_fail".into(), None),
+        }
+    }
+}
+
+impl Default for ValidatorMetricsValue {
+    /// Initialize with empty metrics
+    fn default() -> Self {
+        Self::new(&*NoMetrics::boxed())
+    }
+}
+
+
 /// initialize prom metrics
 #[must_use]
 pub fn init_metrics(port: Option<u16>, metrics_folder: Option<String>, metrics_interva_sec: usize) -> Arc<PrometheusMetrics> {
@@ -282,8 +319,13 @@ async fn start_consensus<
     // Start a new tokio tcp listener that acts as RPC server, exposing the following functions:
     // * send_txs - accepts a single arg 'txs' (Vec<Vec<u8>>)
     let (tx_send, mut tx_recv) = tokio::sync::mpsc::channel(100);
+    let rpc_metrics = if let Some(m)  = met.clone() {
+        RpcMetricsValue::new(&*Arc::<PrometheusMetrics>::clone(&m))
+    } else {
+        RpcMetricsValue::default()
+    }; 
     tokio::spawn(async move {
-        start_rpc(rpc_port, tx_send.clone()).await;
+        start_rpc(rpc_port, tx_send.clone(), rpc_metrics).await;
     });
 
     if let Some(m)  = met.clone() {
@@ -308,12 +350,12 @@ async fn start_consensus<
         None => init_metrics(None, None, 0),
     };
 
-
     // Spawn the task to wait for events
     let join_handle = tokio::spawn(async move {
         let metrics = Arc::<PrometheusMetrics>::clone(&metrics_cloned);
         let metrics_interval_sec = metrics.get_interva_sec();
         let mut metrics_interval = tokio::time::interval(Duration::from_secs(metrics_interval_sec as u64));
+        let validator_metrics = ValidatorMetricsValue::new(&*metrics);
         // Get the event stream for this particular node
         let mut event_stream = handle.event_stream();
         // Wait for a `Decide` event for the view number we requested
@@ -346,8 +388,10 @@ async fn start_consensus<
                             .put(non_crypto_hash(&tx_bytes), Instant::now());
                     }
                     if let Err(err) = handle.submit_transaction(TestTransaction::new(tx_bytes)).await {
+                        validator_metrics.num_tx_submit_fail.add(1); 
                         tracing::error!("Failed to submit transaction: {:?}", err);
                     } else {
+                        validator_metrics.num_tx_submitted.add(1);
                         tracing::info!("Transaction submitted successfully (size: {n})");
                     }
                 }
@@ -386,6 +430,9 @@ async fn start_consensus<
                         }
                         
                         info!("Proposed block size: {sum} bytes, num transactions: {num_transactions}");
+                        validator_metrics.num_block_proposed.add(1);
+                        validator_metrics.num_block_size_proposed.add(sum);
+                        validator_metrics.num_tx_proposed.add(num_transactions);
 
                         // Insert the size of the proposed block and the number of transactions into the cache.
                         // We use this to log the size of the proposed block when we decide on a view

--- a/crates/examples/rpc.rs
+++ b/crates/examples/rpc.rs
@@ -5,6 +5,36 @@ use tokio::sync::mpsc::Sender;
 
 use serde_derive::{Deserialize, Serialize};
 
+use hotshot_types::traits::metrics::{Metrics, Counter, NoMetrics};
+
+/// RPC-specific metrics
+#[derive(Clone, Debug)]
+pub struct RpcMetricsValue {
+    /// The number of received RPC requests
+    pub num_recv_req: Box<dyn Counter>,
+    /// The number of txs received
+    pub num_recv_tx: Box<dyn Counter>,
+
+}
+
+impl RpcMetricsValue {
+    /// Populate the metrics with RPC-specific metrics
+    pub fn new(metrics: &dyn Metrics) -> Self {
+        let subgroup = metrics.subgroup("rpc".into());
+        Self {
+            num_recv_req: subgroup.create_counter("num_recv_req".into(), None),
+            num_recv_tx: subgroup.create_counter("num_recv_tx".into(), None),
+        }
+    }
+}
+
+impl Default for RpcMetricsValue {
+    /// Initialize with empty metrics
+    fn default() -> Self {
+        Self::new(&*NoMetrics::boxed())
+    }
+}
+
 /// RPC request structure
 #[derive(Deserialize, Serialize, Debug)]
 struct RpcRequest {
@@ -30,13 +60,15 @@ struct RpcResponse {
 }
 
 /// Starts the RPC server, returns a future that resolves when the server stops or fails
-pub async fn start_rpc(rpc_port: u16, tx_send: Sender<Vec<u8>>) {
+pub async fn start_rpc(rpc_port: u16, tx_send: Sender<Vec<u8>>, metrics: RpcMetricsValue) {
     let tx_send_filter = warp::any().map(move || tx_send.clone());
-    
+    let metrics_filter = warp::any().map(move || metrics.clone());
+
     let jrpc = warp::post()
         .and(warp::body::content_length_limit(1024 * 16))
         .and(warp::body::json())
         .and(tx_send_filter)
+        .and(metrics_filter)
         .and_then(handle_rpc_request);
 
     tracing::debug!("Starting RPC server on: 0.0.0.0:{}", rpc_port);
@@ -45,9 +77,10 @@ pub async fn start_rpc(rpc_port: u16, tx_send: Sender<Vec<u8>>) {
 }
 
 /// Handles an RPC request
-async fn handle_rpc_request(req: RpcRequest, tx_send: Sender<Vec<u8>>) -> Result<impl warp::Reply, warp::Rejection> {
+async fn handle_rpc_request(req: RpcRequest, tx_send: Sender<Vec<u8>>, metrics: RpcMetricsValue) -> Result<impl warp::Reply, warp::Rejection> {
     match req.method.as_str() {
         "ping" => {
+            metrics.num_recv_req.add(1);
             let response = RpcResponse {
                 jsonrpc: "2.0".to_string(),
                 result: json!("pong"),
@@ -56,9 +89,11 @@ async fn handle_rpc_request(req: RpcRequest, tx_send: Sender<Vec<u8>>) -> Result
             Ok(warp::reply::json(&response))
         }
         "send_txs" => {
+            metrics.num_recv_req.add(1);
             if let Some(txs) = req.params.get("txs").and_then(|v| v.as_array()) {
                 match rpc_send_txs(txs, tx_send).await {
                     Ok(()) => {
+                        metrics.num_recv_tx.add(txs.len());
                         let response = RpcResponse {
                             jsonrpc: "2.0".to_string(),
                             result: json!(true),
@@ -102,3 +137,4 @@ async fn rpc_send_txs(txs: &[serde_json::Value], tx_send: Sender<Vec<u8>>) -> Re
     }
     Ok(())
 }
+


### PR DESCRIPTION
- `validator_num_block_proposed`: number of blocks proposed by the validator
- `validator_num_block_size_proposed`: number of bytes in the blocks proposed by the validator
- `validator_num_tx_proposed`: number of tx proposed by the validator
- `validator_num_tx_submitted: number of tx submitted by the validator
- `validator_num_tx_submit_fail`: number of failed submit attempts
- `rpc_num_recv_req`: number of received RPC requests
- `rpc_num_recv_tx`: number of txs received
